### PR TITLE
fix(docs): fix `FreeRTOSConfig.h` inclusion header instructions to be compatible with asm ports.

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 [Introduction](./intro.md)
 # Documentation
-- [Getting Started](./doc/getting_started.md)
+- [Getting Started + Integration](./doc/getting_started.md)
 - [Porting](./doc/porting.md)
     - [Critical Sections](./doc/porting_critical_sections.md)
 - [Configuration](./doc/config.md)

--- a/docs/doc/getting_started.md
+++ b/docs/doc/getting_started.md
@@ -4,9 +4,20 @@
 
 Add all source files from [`tband/src`](https://github.com/schilkp/Tonbandgeraet/tree/main/tband/src) to your project
 and place all headers from [`tband/inc`](https://github.com/schilkp/Tonbandgeraet/tree/main/tband/inc) inside a folder
-that is recognized as an include path.
+that is available as an include path.
 
-If you are using FreeRTOS, include `tband.h` at the end of the `FreeRTOSConfig.h` header.
+If you are using FreeRTOS, include `tband.h` at the end of the `FreeRTOSConfig.h` header:
+
+```c
+#ifndef __ASSEMBLER__
+#include "tband.h"
+#endif
+```
+
+```admonish note
+The `__ASSEMBLER__` guard is required as some FreeRTOS [ports](https://esp32.com/viewtopic.php?t=22738)
+include the header from assembly files.
+```
 
 To use the tracer, only include `tband.h` in your code. Do not directly include any other Tonbandgerät headers.
 Note that Tonbandgerät is written using C11. Older versions of C are not tested.

--- a/examples/POSIX_FreeRTOS/inc/FreeRTOSConfig.h
+++ b/examples/POSIX_FreeRTOS/inc/FreeRTOSConfig.h
@@ -107,7 +107,9 @@ to exclude the API function. */
 // === Tracing =====================================================================================
 
 // Include tracer:
+#ifndef __ASSEMBLER__
 #include "tband.h"
+#endif
 
 #endif /* FREERTOS_CONFIG_H */
 // clang-format on

--- a/examples/STM32L476RGT6_FreeRTOS/Core/Inc/FreeRTOSConfig.h
+++ b/examples/STM32L476RGT6_FreeRTOS/Core/Inc/FreeRTOSConfig.h
@@ -146,6 +146,8 @@ standard names. */
 // === Tracing =====================================================================================
 
 // Include tracer:
+#ifndef __ASSEMBLER__
 #include "tband.h"
+#endif
 
 #endif /* FREERTOS_CONFIG_H */


### PR DESCRIPTION
Fixes #12